### PR TITLE
added link to new image doc

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@ Github repository. Here is the list of official Torch packages:</p>
         <a href="https://github.com/torch/image">image</a>
     </td>
     <td>
-        N/A
+        <a href="https://github.com/torch/image/blob/master/README.md">doc</a>
     </td>
     <td>
         image transform routines, color spaces, I/O, ...


### PR DESCRIPTION
This PR adds a link to the new image package documentation. It depends on https://github.com/torch/image/pull/35 . 
