### PR TITLE
docs/00-getting-started.md: Avoid use of -k in curl for security reasons

### DIFF
--- a/docs/00-getting-started.md
+++ b/docs/00-getting-started.md
@@ -14,7 +14,7 @@ Torch can be installed to your home folder in ~/torch by running these three com
 
 ```bash
 # in a terminal, run the commands
-curl -sk https://raw.githubusercontent.com/torch/ezinstall/master/install-deps | bash
+curl -s https://raw.githubusercontent.com/torch/ezinstall/master/install-deps | bash
 git clone https://github.com/torch/distro.git ~/torch --recursive
 cd ~/torch; ./install.sh
 ```


### PR DESCRIPTION
The `-k` (`--insecure`) flag disables the TLS certificate verifications, allowing anyone to impersonate the source to serve a malicious version of the script.  See also: https://github.com/torch/distro/pull/28