### PR TITLE
Fix link in blog post

### DIFF
--- a/blog/_posts/2015-09-21-rmva.md
+++ b/blog/_posts/2015-09-21-rmva.md
@@ -28,7 +28,7 @@ These small sensed areas are refered to as *glimpses*.
 
 Actually, the paper's glimpse sensor is little bit more 
 complicated than what we described above, but nevertheless simple. 
-Keeping in step with the modular spirit of [Torch7]'s [nn] package, we created a 
+Keeping in step with the modular spirit of [Torch7](https://github.com/torch/torch7)'s [nn](https://github.com/torch/nn) package, we created a 
 [SpatialGlimpse](https://github.com/nicholas-leonard/dpnn#nn.SpatialGlimpse) module.
 
 ```lua


### PR DESCRIPTION
Minor fix. I believe the link was missing. Or was is meant to be bold/italic ?