### PR TITLE
Remove reference to FPGA backend on homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,7 +19,7 @@ A summary of core features:
 * neural network, and energy-based models
 * numeric optimization routines
 * Fast and efficient GPU support
-* Embeddable, with ports to iOS, Android and FPGA backends
+* Embeddable, with ports to iOS and Android backends
 
 
 ##Why Torch?


### PR DESCRIPTION
There no longer exists a maintained FPGA backend for Torch.  Thus the reference on the homepage should be removed.  As discussed in issue #63.